### PR TITLE
Update to use node 16, node 12 is deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ outputs:
   contributors:
     description: 'Merged list of all collaborators'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Per this GitHub blog -- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

# Pull Request

## Description

_Please delete the italicised instruction text!
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that are required for this change._

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
